### PR TITLE
fixing summery step text

### DIFF
--- a/src/main/java/Functions.java
+++ b/src/main/java/Functions.java
@@ -873,7 +873,10 @@ public class Functions {
 
             // end of guide
             if (listOfLines.get(i).startsWith("# Great work! You're done!")) {
-                String lastLine = listOfLines.get(i + 2).replaceAll("`","**");
+                String lastLine = listOfLines.get(i + 2);
+                if (lastLine.contains("`")) {
+                    lastLine = lastLine.replaceAll("`","**");
+                }
                 listOfLines.set(i + 2, "");
                 finish(listOfLines, lastLine, guideName, i);
             }

--- a/src/main/java/Functions.java
+++ b/src/main/java/Functions.java
@@ -873,7 +873,7 @@ public class Functions {
 
             // end of guide
             if (listOfLines.get(i).startsWith("# Great work! You're done!")) {
-                String lastLine = listOfLines.get(i + 2);
+                String lastLine = listOfLines.get(i + 2).replaceAll("`","**");
                 listOfLines.set(i + 2, "");
                 finish(listOfLines, lastLine, guideName, i);
             }


### PR DESCRIPTION
Added a conditional method to make sure that any inline codeblocks (`"`"`) are converter to bold text (`**`) (as we do in Cloud-hosted-guides). The condition is there to avoid any future failures where there isn't a `"`"` in the lastLine. 